### PR TITLE
move inputs to @Component decorator

### DIFF
--- a/src/TranslateComponent.ts
+++ b/src/TranslateComponent.ts
@@ -2,12 +2,16 @@ import {TranslateLogHandler} from "./TranslateLogHandler";
 import {Translator} from "./Translator";
 import {TranslatorContainer} from "./TranslatorContainer";
 
-import {Component, Inject, Input} from "@angular/core";
+import {Component, Input} from "@angular/core";
 import {Subscription} from "rxjs/Subscription";
 
 @Component({
     selector: "[translate]",
     template: "{{translation}}",
+    inputs: [
+        "params:translateParams",
+        "module:translatorModule",
+    ],
 })
 export class TranslateComponent {
     public translation: string = "";
@@ -31,7 +35,7 @@ export class TranslateComponent {
         this.startTranslation();
     }
 
-    @Input("translateParams") set params(params: any) {
+    set params(params: any) {
         if (typeof params !== "object") {
             this.logHandler.error("Params have to be an object");
             return;
@@ -41,7 +45,7 @@ export class TranslateComponent {
         this.startTranslation();
     }
 
-     @Input("translatorModule") set module(module: string) {
+    set module(module: string) {
         if (this.subscription) {
             this.subscription.unsubscribe();
         }
@@ -50,7 +54,7 @@ export class TranslateComponent {
             this.startTranslation();
         });
         this.startTranslation();
-     }
+    }
 
     private startTranslation() {
         if (!this._key) {

--- a/tests/TranslateComponent.spec.ts
+++ b/tests/TranslateComponent.spec.ts
@@ -5,9 +5,10 @@ import {
     Translator,
     TranslatorConfig,
     TranslatorContainer,
+    TranslatorModule,
 } from "../index";
 
-import {ReflectiveInjector} from "@angular/core";
+import {Component, ReflectiveInjector} from "@angular/core";
 import {fakeAsync, flushMicrotasks, TestBed} from "@angular/core/testing";
 import {JasmineHelper} from "./helper/JasmineHelper";
 import {TranslateLogHandlerMock, TranslationLoaderMock} from "./helper/TranslatorMocks";
@@ -223,6 +224,35 @@ describe("TranslateComponent", () => {
 
                 expect(anotherTranslator.translate).toHaveBeenCalledWith("TEXT", {});
             });
+        });
+    });
+
+    describe("within module", () => {
+        let translator: Translator;
+
+        @Component({
+            selector: "my-component",
+            template: `<p translate="TEXT" [translateParams]="{ some: 'value' }"></p>`,
+        })
+        class MyComponent {}
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [ TranslatorModule.forRoot() ],
+                declarations: [ MyComponent ],
+            });
+
+            translator = TestBed.get(Translator);
+            spyOn(translator, "translate").and.returnValue(Promise.resolve("some text"));
+        });
+
+        it("first resolves the parameters", () => {
+            let component = TestBed.createComponent(MyComponent);
+
+            component.detectChanges();
+
+            expect(translator.translate).toHaveBeenCalledWith("TEXT", { some: "value" });
+            expect(JasmineHelper.calls(translator.translate).count()).toBe(1);
         });
     });
 });


### PR DESCRIPTION
The inputs from @Component decorator get executed earlier than @Input
decorators. This way the parameters get set before translate get called.

This will solve #32 