### PR TITLE
give PipeResolver a new JitReflector if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "typings install",
     "prepublishOnly": "npm test && npm run build",
     "coveralls": "cat coverage/lcov.info | coveralls",
-    "build": "ngc && webpack"
+    "build": "tsc && ngc && webpack"
   },
   "keywords": [
     "angular2",
@@ -53,7 +53,7 @@
     "@angular/platform-browser-dynamic": "4.*",
     "awesome-typescript-loader": "*",
     "istanbul-instrumenter-loader": "*",
-    "jasmine-core": "*",
+    "jasmine-core": "2.5.*",
     "karma": "*",
     "karma-chrome-launcher": "*",
     "karma-coverage": "*",

--- a/src/TranslatorConfig.ts
+++ b/src/TranslatorConfig.ts
@@ -13,8 +13,12 @@ import {
     TitleCasePipe,
     UpperCasePipe,
 } from "@angular/common";
-import { PipeResolver } from "@angular/compiler";
+import * as compiler from "@angular/compiler";
 import { PipeTransform, Type } from "@angular/core";
+
+const PipeResolver = compiler.PipeResolver;
+// tslint:disable-next-line:no-string-literal
+const JitReflector = compiler["JitReflector"] ? compiler["JitReflector"] : void(0);
 
 export const COMMON_PURE_PIPES: Array<Type<PipeTransform>> = [
     CurrencyPipe,
@@ -61,7 +65,7 @@ export class TranslatorConfig {
         loader:             TranslationLoaderJson,
         pipes:              COMMON_PURE_PIPES.slice(0),
         pipeMap:            (() => {
-            const pipeResolver = new PipeResolver();
+            const pipeResolver = new PipeResolver(JitReflector ? new JitReflector() : void(0));
             let pipes = {};
             COMMON_PURE_PIPES.map((pipe) => {
                 pipes[pipeResolver.resolve(pipe).name] = pipe;
@@ -131,7 +135,7 @@ export class TranslatorConfig {
     get pipes(): { [key: string]: Type<PipeTransform> } {
         if (!this.pipeMap) {
             this.pipeMap = this.options.pipeMap;
-            const pipeResolver = new PipeResolver();
+            const pipeResolver = new PipeResolver(JitReflector ? new JitReflector() : void(0));
             const mappedPipes = Object.keys(this.pipeMap).map((key) => this.pipeMap[key]);
             const unmappedPipes = this.options.pipes.filter((pipe) => mappedPipes.indexOf(pipe) === -1);
             while (unmappedPipes.length) {


### PR DESCRIPTION
For backward compatibility we use `import *` and check if there exists a JitReflector.

This will solve #46 