### PR TITLE
Update TranslateComponent.ts

### DIFF
--- a/src/TranslateComponent.ts
+++ b/src/TranslateComponent.ts
@@ -7,7 +7,7 @@ import { Subscription } from "rxjs/Subscription";
 
 @Component({
     selector: "translate",
-    template: "{{ translation }}"
+    template: "{{ translation }}",
 })
 export class TranslateComponent {
     public translation: string = "";

--- a/src/TranslateComponent.ts
+++ b/src/TranslateComponent.ts
@@ -6,12 +6,8 @@ import { Component, Input } from "@angular/core";
 import { Subscription } from "rxjs/Subscription";
 
 @Component({
-    selector: "[translate]",
-    template: "{{translation}}",
-    inputs:   [
-        "params:translateParams",
-        "module:translatorModule",
-    ],
+    selector: "translate",
+    template: "{{ translation }}"
 })
 export class TranslateComponent {
     public translation: string = "";
@@ -35,7 +31,7 @@ export class TranslateComponent {
         this.startTranslation();
     }
 
-    set params(params: any) {
+    @Input("translateParams") set params(params: any) {
         if (typeof params !== "object") {
             this.logHandler.error("Params have to be an object");
             return;
@@ -45,7 +41,7 @@ export class TranslateComponent {
         this.startTranslation();
     }
 
-    set module(module: string) {
+    @Input("translatorModule") set module(module: string) {
         if (this.subscription) {
             this.subscription.unsubscribe();
         }

--- a/tests/TranslateComponent.spec.ts
+++ b/tests/TranslateComponent.spec.ts
@@ -232,7 +232,8 @@ describe("TranslateComponent", () => {
 
         @Component({
             selector: "my-component",
-            template: `<p translate="TEXT" [translateParams]="{ some: 'value' }"></p>`,
+            template: `<p><translate [translate]="'TEXT'" [translateParams]="{ some: 'value' }">
+                       </translate></p>`,
         })
         class MyComponent {}
 


### PR DESCRIPTION
To fix (angular's default) tslint errors. These errors should definitely be fixed, because with tslint it is currently not possible to exclude folders when running `ng lint`. So these tslint errors cause our CI build to fail...

These were the errors:
```
ERROR: D:/projects/komed-health-web/node_modules/angular-translator/src/TranslateComponent.ts[10, 16]: Missing whitespace in interpolation; expecting {{ expr }}
ERROR: D:/projects/komed-health-web/node_modules/angular-translator/src/TranslateComponent.ts[9, 15]: The selector of the component "TranslateComponent" should be used as element (https://angular.io/st
yleguide#style-05-03)
ERROR: D:/projects/komed-health-web/node_modules/angular-translator/src/TranslateComponent.ts[11, 5]: Use the @Input property decorator instead of the inputs property (https://angular.io/styleguide#sty
le-05-12
```