### PR TITLE
allow full language names in TranslatorConfig

### DIFF
--- a/docs/TranslatorConfig.md
+++ b/docs/TranslatorConfig.md
@@ -25,7 +25,7 @@ to do so.
 | Name                  | Type     | Default  | Description |
 |-----------------------|----------|----------|-------------|
 | defaultLanguage       | string   | `'en'`   | Defines the default language to be used if no language got set and language detection is disabled or does not detect a language. |
-| providedLanguages     | string[] | `['en']` | Defines a list of the languages that are supported from you. The provided languages has to match your file names. To make language detection work you should use the ISO format 639-1 (e.g. 'en') or the IETF language tag (e.g. 'de-AT'). You don't have to use "-" and don't have to care about case sensitive. A language 'en/us' will also match a browser language en-US and vise versa - but the file has to be *path*\*en/us\**extension* then. |
+| providedLanguages     | string[] | `['en']` | Defines a list of the languages that are supported from you. The provided languages has to match your file names. To make language detection work you should use the ISO format 639-1 (e.g. 'en') or the IETF language tag (e.g. 'de-AT'). You don't have to use "-" and don't have to care about case sensitive. A language 'en/us' will also match a browser language en-US and vise versa - but the file has to be *path**en/us**extension* then. |
 | detectLanguage        | boolean  | `true`   | Defines whether the language should be detected by navigator.language(s) when TranslateService got initialized or not. |
 | loader                | Type     | `TranslationLoaderJson` | The loader that is used for loading translations. |
 | loaderOptions         | any      | `{}`     | Options that are passed to the loader. |
@@ -38,14 +38,9 @@ to do so.
 Tries to find matching provided language and returns the provided language. The provided language and the language that
 is searched are getting normalized for matching. That means that `'EN/usa'` is getting `'en-US'`.
 
-Only valid language/region combinations are allowed. This is necessary to exclude finding provided language Breton
-if the browser says `"british"`. Valid in this case means to use this format: 
+Only valid language/region combinations are allowed for non-strict matching. This is necessary to exclude finding provided language Breton if the browser says `"british"`. Valid in this case means to use this format: 
 `<two letter language>[[divider]<two letter region>]`. Or - to be more precise - this regular expression: 
-`/^([A-Za-z]{2})(?:[\.\-_\/]?([A-Za-z]{2}))?$/`.
-
-Because the setter for `Translator.language` and `TranslatorContainer.language` is checking if the language is provided
-it is necessary that your provided languages matches against this regular expression too. Otherwise you will not be
-able to switch to this language.
+`/^([A-Za-z]{2})(?:[.\-_\/]?([A-Za-z]{2}))?$/`.
 
 Example:
 

--- a/src/TranslatorConfig.ts
+++ b/src/TranslatorConfig.ts
@@ -35,6 +35,8 @@ export const COMMON_PURE_PIPES: Array<Type<PipeTransform>> = [
 export class TranslatorConfig {
     public static navigator: any = window && window.navigator ? window.navigator : {};
 
+    private static isoRegEx = /^([A-Za-z]{2})(?:[.\-_\/]?([A-Za-z]{2}))?$/;
+
     /**
      * Normalize a language
      *
@@ -42,12 +44,11 @@ export class TranslatorConfig {
      * @returns {string}
      */
     private static normalizeLanguage(languageString: string): string {
-        let regExp = /^([A-Za-z]{2})(?:[.\-_\/]?([A-Za-z]{2}))?$/;
-        if (!languageString.match(regExp)) {
-            return "";
+        if (!languageString.match(TranslatorConfig.isoRegEx)) {
+            return languageString;
         }
         return languageString.replace(
-            regExp,
+            TranslatorConfig.isoRegEx,
             (substring: string, language: string, country: string = "") => {
                 language = language.toLowerCase();
                 country = country.toUpperCase();
@@ -200,33 +201,34 @@ export class TranslatorConfig {
      * @returns {string|boolean}
      */
     public providedLanguage(language: string, strict: boolean = false): string | boolean {
-        let provided: string | boolean = false;
-        let p: number;
-
         let providedLanguagesNormalized = this.providedLanguages.map(TranslatorConfig.normalizeLanguage);
         language = TranslatorConfig.normalizeLanguage(language);
 
         if (language.length === 0) {
-            return provided;
+            return false;
         }
 
-        p = providedLanguagesNormalized.indexOf(language);
+        let p: number = providedLanguagesNormalized.indexOf(language);
         if (p > -1) {
-            provided = this.providedLanguages[p];
-        } else if (!strict) {
+            return this.providedLanguages[p];
+        } else if (!strict && language.match(TranslatorConfig.isoRegEx)) {
             language = language.substr(0, 2);
             p = providedLanguagesNormalized.indexOf(language);
             if (p > -1) {
-                provided = this.providedLanguages[p];
+                return this.providedLanguages[p];
             } else {
-                p = providedLanguagesNormalized.map((l) => l.substr(0, 2)).indexOf(language);
+                p = providedLanguagesNormalized
+                    .map((l) => {
+                        return l.match(TranslatorConfig.isoRegEx) ? l.substr(0, 2) : l;
+                    })
+                    .indexOf(language);
                 if (p > -1) {
-                    provided = this.providedLanguages[p];
+                    return this.providedLanguages[p];
                 }
             }
         }
 
-        return provided;
+        return false;
     }
 
     /**

--- a/src/TranslatorConfig.ts
+++ b/src/TranslatorConfig.ts
@@ -204,10 +204,6 @@ export class TranslatorConfig {
         let providedLanguagesNormalized = this.providedLanguages.map(TranslatorConfig.normalizeLanguage);
         language = TranslatorConfig.normalizeLanguage(language);
 
-        if (language.length === 0) {
-            return false;
-        }
-
         let p: number = providedLanguagesNormalized.indexOf(language);
         if (p > -1) {
             return this.providedLanguages[p];

--- a/tests/TranslatorConfig.spec.ts
+++ b/tests/TranslatorConfig.spec.ts
@@ -162,6 +162,36 @@ describe("TranslatorConfig", () => {
 
             expect(providedLanguage).toBeFalsy();
         });
+
+        it("allows full language names", () => {
+            translatorConfig = new TranslatorConfig(logHandler, {
+                providedLanguages: ["klingon", "en"],
+            });
+
+            let providedLanguage = translatorConfig.providedLanguage("klingon");
+
+            expect(providedLanguage).toBe("klingon");
+        });
+
+        it("full language names can not be found in non-strict mode", () => {
+            translatorConfig = new TranslatorConfig(logHandler, {
+                providedLanguages: ["klingon", "en"],
+            });
+
+            let providedLanguage = translatorConfig.providedLanguage("kl");
+
+            expect(providedLanguage).toBeFalsy();
+        });
+
+        it("finds languages within provided languages in non-strict mode", () => {
+            translatorConfig = new TranslatorConfig(logHandler, {
+                providedLanguages: ["klingon", "en_US"],
+            });
+
+            let providedLanguage = translatorConfig.providedLanguage("en");
+
+            expect(providedLanguage).toBe("en_US");
+        });
     });
 
     describe("navigatorLanguages", () => {


### PR DESCRIPTION
The language format restriction is only necessary for partial matching
(non-strict) and a language without that format is still a valid match.

This will solve #62 